### PR TITLE
[Azure Email] Fix CC and BCC sending to the wrong email addresses

### DIFF
--- a/src/Senders/FluentEmail.Azure.Email/AzureEmailSender.cs
+++ b/src/Senders/FluentEmail.Azure.Email/AzureEmailSender.cs
@@ -84,14 +84,14 @@ public class AzureEmailSender : ISender
         
         if(email.Data.CcAddresses.Any())
         {
-            email.Data.CcAddresses.ForEach(r => ccRecipients.Add(new EmailAddress($"cc{r.EmailAddress}", r.Name)));
+            email.Data.CcAddresses.ForEach(r => ccRecipients.Add(new EmailAddress(r.EmailAddress, r.Name)));
         }
         
         var bccRecipients = new List<EmailAddress>();
         
         if(email.Data.BccAddresses.Any())
         {
-            email.Data.BccAddresses.ForEach(r => bccRecipients.Add(new EmailAddress($"bcc{r.EmailAddress}", r.Name)));
+            email.Data.BccAddresses.ForEach(r => bccRecipients.Add(new EmailAddress(r.EmailAddress, r.Name)));
         }
         
         var emailRecipients = new EmailRecipients(toRecipients, ccRecipients, bccRecipients);


### PR DESCRIPTION
The CC and BCC logic prepends cc and bcc on the email address which makes them get send to the wrong email addresses. I don't know why it was written this way, I guess for debugging purposes but it is wrong at the very least in real scenarios.