### PR TITLE
feat: allow configuring Liquid parser 

### DIFF
--- a/src/Renderers/FluentEmail.Liquid/LiquidRenderer.cs
+++ b/src/Renderers/FluentEmail.Liquid/LiquidRenderer.cs
@@ -19,6 +19,7 @@ namespace FluentEmail.Liquid
         {
             _options = options;
             _parser = new LiquidParser();
+            _options.Value.ConfigureParser?.Invoke(_parser);
         }
 
         public string Parse<T>(string template, T model, bool isHtml = true)

--- a/src/Renderers/FluentEmail.Liquid/LiquidRendererOptions.cs
+++ b/src/Renderers/FluentEmail.Liquid/LiquidRendererOptions.cs
@@ -30,5 +30,10 @@ namespace FluentEmail.Liquid
         /// Set custom Template Options for Fluid 
         /// </summary>
         public TemplateOptions TemplateOptions { get; set; } = new TemplateOptions();
+
+        /// <summary>
+        /// Allows configuring parser
+        /// </summary>
+        public Action<LiquidParser>? ConfigureParser { get; set; }
     }
 }


### PR DESCRIPTION
I was updating FluentEmail to latest version and came a cross an issue which this PR hopefully fixes.

In Fluid.Core 1.x you could register custom tags using a static class which meant that one could easily add those e.g. in startup class. However Fluid.Core 2.x changed how tags are handled and I couldn't find any other way to configure those than to call RegisterXYZ method on FluidParser. As the parser instance used by FluentEmail is created in LiquidRenderer there is no way to configure it from app using FluentEmail. This PR adds a new option to configure the parser after it is created.