### PR TITLE
Bind MailgunSender to ISender in singleton scope. 

### DIFF
--- a/src/Renderers/FluentEmail.Liquid/LiquidRendererOptions.cs
+++ b/src/Renderers/FluentEmail.Liquid/LiquidRendererOptions.cs
@@ -29,6 +29,6 @@ namespace FluentEmail.Liquid
         /// <summary>
         /// Set custom Template Options for Fluid 
         /// </summary>
-        public TemplateOptions TemplateOptions { get; set; } = new();
+        public TemplateOptions TemplateOptions { get; set; } = new TemplateOptions();
     }
 }


### PR DESCRIPTION
Bind MailgunSender to ISender in singleton scope.

MailgunSender creates a new HttpClient for each instance of a MailgunSender object.

Based on Microsoft recommendations https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines#recommended-use I propose the MailgunSender should be bound in Singleton scope so that only one HttpClient is instantiated.