### PR TITLE
Updated FluentEmail.MailerSend package reference in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Original blog post here for a detailed guide [A complete guide to send email in 
 - [FluentEmail.Mailtrap](src/Senders/FluentEmail.Mailtrap) - Send emails to Mailtrap. Uses [FluentEmail.Smtp](src/Senders/FluentEmail.Smtp) for delivery.
 - [FluentEmail.MailKit](src/Senders/FluentEmail.MailKit) - Send emails using the [MailKit](https://github.com/jstedfast/MailKit) email library.
 - [FluentEmail.MailPace](src/Senders/FluentEmail.MailPace) - Send emails via the [MailPace](https://www.mailpace.com/) REST API.
-- [FluentEmail.MailerSend](https://github.com/marcoatribeiro/FluentEmail.MailerSend) - Send email via [MailerSend](https://www.mailersend.com/)'s API.
+- [FluentEmail.MailerSend](https://github.com/marcoatribeiro/FluentEmail.MailerSend.jcamp) - Send email via [MailerSend](https://www.mailersend.com/)'s API.
 
 ## Basic Usage
 


### PR DESCRIPTION
Hi @JohnCampionJr!

First of all congratulations for the amazing job on updating this library and keeping this project alive!

I have also created a new version of the MailerSend sender to be compatible with your fork, as it is not compatible with .NET Standard. In order to distinguish it from the original (and keep your fork's standards) I also prefixed the package with **jcamp**: [jcamp.FluentEmail.MailerSend](https://www.nuget.org/packages/jcamp.FluentEmail.MailerSend).

This PR is meant only to update the Readme file with the reference to the new package.