### PR TITLE
Adds CheckCertificateRevocation to mailkit sender async path.

### DIFF
--- a/src/Senders/FluentEmail.MailKit/MailKitSender.cs
+++ b/src/Senders/FluentEmail.MailKit/MailKitSender.cs
@@ -133,6 +133,7 @@ namespace FluentEmail.MailKitSmtp
 
                 using (var client = _protocolLogger == null ? new SmtpClient() : new SmtpClient(_protocolLogger))
                 {
+                    client.CheckCertificateRevocation = _smtpClientOptions.CheckCertificateRevocation;
                     if (_smtpClientOptions.ServerCertificateValidationCallback != null)
                     {
                         client.ServerCertificateValidationCallback = _smtpClientOptions.ServerCertificateValidationCallback;


### PR DESCRIPTION
The newly added CheckCertificateRevocation property was only referenced in the synchronous send method in the mailkit sender; this adds it to the async path as well.